### PR TITLE
Removing "How to Contribute" appearing twice on README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -22,6 +22,4 @@ The HKNA FIR covers the entirety of Kenya's borders.
 
 ## How to Contribute
 
-## How to Contribute
-
 For more information on how to contribute, please refer to VATSSA's Sector File Development Overview Repository [How to Contribute](https://github.com/VATSIM-SSA/sectorfile-overview/wiki/How-to-Contribute) page.


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

```
[x] Bug Fix
[ ] Feature / Enhancement
[ ] Plugins
[ ] Documentation
[x] Other
```

## Issue Number and Link

#15 

## Describe Your Changes

Removed duplicate "How to Contribute" header in README

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have tested my changes in my local setup
- [x] My changes generate no new warnings
